### PR TITLE
Better handling for io

### DIFF
--- a/cd/index.mjs
+++ b/cd/index.mjs
@@ -54,5 +54,5 @@ export const run = async ({ config, args, cd }) => {
     return;
   }
 
-  cd(mathced.path);
+  await cd(mathced.path);
 };

--- a/clone/index.mjs
+++ b/clone/index.mjs
@@ -113,7 +113,7 @@ export const run = async ({ config, args, cd }) => {
   if (fs.existsSync(clonePath)) {
     console.log(`Clone path "${clonePath}" already exists.`);
     if (changeDirectory) {
-      cd(clonePath);
+      await cd(clonePath);
     }
     return;
   }
@@ -127,6 +127,6 @@ export const run = async ({ config, args, cd }) => {
   }
 
   if (changeDirectory) {
-    cd(clonePath);
+    await cd(clonePath);
   }
 };

--- a/index.mjs
+++ b/index.mjs
@@ -2,12 +2,21 @@
 
 import { Searcher } from "fast-fuzzy";
 import { load } from "./config/index.mjs";
+import fs from "fs";
 
 const { config, writeConfig } = load();
 const modules = ["config", "default", "clone", "cd", "shell", "update", "open"];
 
-const cd = (path) => {
-  console.error(`COMMAND cd ${path}`);
+const writeToFD = async (fd, str) => {
+  return new Promise((resolve) => {
+    fs.write(fd, str, () => {
+      resolve();
+    });
+  });
+};
+
+const cd = async (path) => {
+  return await writeToFD(9, `cd:${path}\n`);
 };
 
 const findModule = (name) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-cli",
   "type": "module",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "dependencies": {
     "colors": "^1.4.0",


### PR DESCRIPTION
Using 8 and 9 file descriptors to handle executing commands in the main shell. This makes it easier for the `dev-cli` to manage its own stdout and stderr and use spinners in the commandline.