### PR TITLE
use dev instead of dev-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ This is a command-line tool for you to do `dev clone user/repo` to clone repos i
 
 It's easy to add features and stuff to it too if you continue reading.
 
-# dev-cli
+# dev
 
-I made the `dev` (`dev-cli`) tool to make my life easier. The goal is for `dev-cli` to help me navigate different git projects and automate some processes that I do a lot!
+I made the `dev` tool to make my life easier. The goal is for `dev` to help me navigate different git projects and automate some processes that I do a lot!
 
 ## Install
 
 This tool does not live on the npm registery just yet. But you can install it with
 
 ```
-npm i -g amir-s/dev-cli
+npm i -g amir-s/dev
 ```
 
-To unlock the full potential of `dev-cli`, you might want to install the shell module too, simply run
+To unlock the full potential of `dev`, you might want to install the shell module too, simply run
 
 ```
-dev-cli shell install
+dev shell install
 ```
 
 This would automatically add the following line to your shell profile file (`~/.zshrc` or `~/.bashrc`):
@@ -28,41 +28,43 @@ This would automatically add the following line to your shell profile file (`~/.
 eval "$(dev-cli shell init)"
 ```
 
-After restarting your shell (or running equivalent of `source ~/.zshrc`), `dev-cli` creates a function for you called `dev`, which you can use instead of `dev-cli`. You can also [customize the name of the function](https://github.com/amir-s/dev-cli/#global-configs).
+After restarting your shell (or running equivalent of `source ~/.zshrc`), `dev-cli` creates a function for you called `dev` instead of directly executing the `dev` binary. This allows commands like `dev cd` to work.
+
+You can also [customize the name of the function](https://github.com/amir-s/dev/#global-configs).
 
 ## Commands
 
-### `clone <repo>`
+### `dev clone <repo>`
 
 `dev clone <repo>` clones a git repo locally into `~/src/<org>/<user>/<repo>`.
 By default, it'll use `ssh` and also it `cd`s into that said directory (only if shell-module is installed).
 
 `<repo>` can be either full git URL or just the username and repo name:
 
-- `dev clone https://github.com/amir-s/dev-cli`
-- `dev clone amir-s/dev-cli` (`github.com` will be used as the default host)
+- `dev clone https://github.com/amir-s/dev`
+- `dev clone amir-s/dev` (`github.com` will be used as the default host)
 
 #### configs
 
-- `clone.path` (default: `"<home>/src/<org>/<user>/<repo>"`)
+- `dev clone.path` (default: `"<home>/src/<org>/<user>/<repo>"`)
   The clone path.
 - `clone.cd` (default: `true`)
-  If `dev-cli` needs to `cd` into the cloned project after it is done.
+  If `dev` needs to `cd` into the cloned project after it is done.
 - `clone.ssh` (default: `true`)
-  If `dev-cli` is forced to use `ssh` to clone the repo. If set to `false`, it'll use `https`.
+  If `dev` is forced to use `ssh` to clone the repo. If set to `false`, it'll use `https`.
 
 ### `open pr`
 
 Opens the default browser to view or create the PR for the current git branch. If the current branch is not on remote yet, `dev` asks you if you want to push it automatically.
 If a pull request is already made but you want to create a new one, you can run `dev open pr --new` to force create a pull request.
 
-### `cd <name>` (_Only works if [shell module](https://github.com/amir-s/dev-cli/#install) is installed_)
+### `cd <name>` (_Only works if [shell module](https://github.com/amir-s/dev/#install) is installed_)
 
 `dev cd <name>` changes the current working directory to a cloned repo by fuzzy matching the input name.
 
-### `config`
+### `dev config`
 
-You can set overrides for the configuration of `dev-cli`. The configuration files lives in `~/.dev.config.json`.
+You can set overrides for the configuration of `dev`. The configuration files lives in `~/.dev.config.json`.
 
 Example: `dev config set clone.cd false` sets `clone.cd` to `false`. You can unset the value by providing empty value for a key: `dev config set clone.cd`.
 
@@ -70,17 +72,16 @@ You can also read the config file with `dev config read`.
 
 #### Global Configs
 
-- `shell.function` (default: `dev`): You can rename the [shell module](https://github.com/amir-s/dev-cli/#install) function with `dev config set shell.function whatever`. After restarting your shell, you can use `whatever` instead of `dev`.
-  Do not rename the function to `dev-cli`. It'll conflict with the binary in `npm` and causes function to call itself recursively. It doesn't break your system, but it makes `dev-cli` not work.
+- `shell.function` (default: `dev`): You can rename the [shell module](https://github.com/amir-s/dev/#install) function with `dev config set shell.function whatever`. After restarting your shell, you can use `whatever` instead of `dev`.
 
-### `update`
+### `dev update`
 
-Run `dev update` to check for updates. You can select to automatially apply the updates, or do it manually with `npm install dev-cli -g`.
+Run `dev update` to check for updates. You can select to automatially apply the updates, or do it manually with `npm install amir-s/dev -g`.
 
 ## Development
 
-You can clone this repo (using `dev-cli` itself, of course) and make changes.
-Assuming you have installed the [shell module](https://github.com/amir-s/dev-cli/#install), you can swap out the production version with your local version of `dev-cli` by `cd`ing into your local copy and running:
+You can clone this repo (using `dev` itself, of course) and make changes.
+Assuming you have installed the [shell module](https://github.com/amir-s/dev/#install), you can swap out the production version with your local version of `dev` by `cd`ing into your local copy and running:
 
 ```
 dev shell use local
@@ -99,5 +100,5 @@ dev shell use prod
 - [ ] More documentation! and have help commands for the current modules.
 - [ ] Notify the user about shell module not being installed when using `dev cd`.
 - [ ] Separate config keys to another method so user can see all possible config keys with `dev config list`.
-- [ ] Run project specific commands, reading scripts from `package.json` or some sort of custom scripts file like `.dev-cli.json`
+- [ ] Run project specific commands, reading scripts from `package.json` or some sort of custom scripts file like `.dev.json`
 - [ ] Make color of the output lines more consistent.

--- a/default/index.mjs
+++ b/default/index.mjs
@@ -4,7 +4,7 @@ import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
 
-const URL = "https://github.com/amir-s/dev-cli";
+const URL = "https://github.com/amir-s/dev";
 
 const getCurrentVersion = () => {
   const __filename = fileURLToPath(import.meta.url);
@@ -23,8 +23,17 @@ export const run = ({ config }) => {
   if (binaryPath && binaryPath !== "dev-cli") {
     console.log(`\n -> ${"Using LOCAL DEV".inverse} @ ${binaryPath.gray}`);
   }
-  console.log(`\n The documentation and this messages are still WIP`.gray);
+  if (binaryPath === undefined) {
+    console.log(
+      "\n Shell module is not installed. Some commands do not work without it."
+        .yellow
+    );
+    console.log(
+      ` You can install it by running ${"dev shell install".inverse}.`.yellow
+    );
+  }
+  console.log(`\n The documentation and this messages are still WIP.`.gray);
   console.log(
-    ` ${"You can check".gray} ${URL.white.underline} ${"to learn more".gray}`
+    ` ${"You can check".gray} ${URL.white.underline} ${"to learn more.".gray}`
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dev-cli",
+  "name": "dev",
   "type": "module",
   "version": "0.0.10",
   "description": "",
@@ -12,18 +12,18 @@
     "zx": "^6.1.0"
   },
   "bin": {
-    "dev-cli": "./index.mjs"
+    "dev-cli": "./index.mjs",
+    "dev": "./index.mjs"
   },
   "devDependencies": {},
-  "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/amir-s/dev-cli.git"
+    "url": "git+https://github.com/amir-s/dev.git"
   },
   "author": "Amir Saboury",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/amir-s/dev-cli/issues"
+    "url": "https://github.com/amir-s/dev/issues"
   },
-  "homepage": "https://github.com/amir-s/dev-cli#readme"
+  "homepage": "https://github.com/amir-s/dev#readme"
 }

--- a/shell/help.mjs
+++ b/shell/help.mjs
@@ -1,18 +1,17 @@
 import "colors";
 
+import report from "yurnalist";
+
 export const generic = () => {
   console.log("No command specified.".gray);
 };
 
 export const shellInstallSuccess = (installCommand, file) => {
-  console.log(`\n Command "${installCommand}" added to "${file}".`.gray);
-  console.log(` ${"You can now use".gray} ${"dev".green} ${"command".gray}`);
-  console.log(
-    `\n ${"You can customize the name of the function (dev) with\n\n".gray} ${
-      " dev config set shell.function <name>\n\n".green
-    }${
-      " to use something other than `dev`. You restart your terminal or run the following command for changes to take effect:\n\n"
-        .gray
-    } ${` source ${file}`.green}`
+  const sourceCommand = `source ${file}`;
+  report.success(`command "${installCommand}" added to "${file}".`);
+
+  report.warn(
+    `please restart your terminal or run ${sourceCommand.inverse} for the changes to take effect.`
+      .yellow
   );
 };

--- a/shell/index.mjs
+++ b/shell/index.mjs
@@ -1,5 +1,6 @@
 import os from "os";
 import path, { dirname } from "path";
+import report from "yurnalist";
 import { fileURLToPath } from "url";
 import { fs } from "zx";
 
@@ -23,7 +24,7 @@ const isDevFolder = () => {
   try {
     const packageFile = path.resolve("./package.json");
     const { name } = JSON.parse(fs.readFileSync(packageFile));
-    return name === "dev-cli";
+    return name === "dev";
   } catch (e) {
     return false;
   }
@@ -55,20 +56,20 @@ export const run = async ({ config, writeConfig, args }) => {
     const installCommand = `eval "$(dev-cli shell init)"`;
     const file = getShellProfile();
     if (!file) {
-      console.log("Unable to find shell profile!");
+      report.error("unable to find shell profile!");
       return;
     }
 
     if (!fs.existsSync(file)) {
-      console.log(`File "${file}" does not exist.`);
+      report.error(`file "${file}" does not exist.`);
       return;
     }
 
     const script = fs.readFileSync(file, "utf8");
 
     if (script.includes(installCommand)) {
-      console.log(
-        `Command \`${installCommand}\` already exists in "${file}".`.yellow
+      report.success(
+        `command \`${installCommand}\` already exists in "${file}".`.yellow
       );
       return;
     }

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -1,6 +1,6 @@
-export DEV_CLI_BIN_PATH="<$SHELL_BIN_PATH$>"
-
 <$SHELL_FN_NAME$>() {
+  export DEV_CLI_BIN_PATH="<$SHELL_BIN_PATH$>"
+
   local tempfile exitcode cmd
 
   tempfile="$(mktemp -u)"


### PR DESCRIPTION
adding two binary commands one for `dev` one for `dev-cli` makes things easier.
`dev` can be used as standalone binary and also as a shell function. the shell function would use `dev-cli` internally to avoid recursion.
